### PR TITLE
Agregar servicio HttpClient en ambos entrypoints: Servidor y Cliente

### DIFF
--- a/DSS_Scoring.Client/Program.cs
+++ b/DSS_Scoring.Client/Program.cs
@@ -2,6 +2,12 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
+// El servicio HttpClient estará disponible en todos los componentes .razor
+// por medio de la inyección de dependencias, ej. -> @inyect HttpClient HttpClient
+builder.Services.AddScoped(sp=> new HttpClient {
+    BaseAddress = new Uri("http://localhost:5173/")
+});
+
 await builder.Build().RunAsync();
 
 builder.Services.AddBlazorBootstrap();

--- a/DSS_Scoring/Program.cs
+++ b/DSS_Scoring/Program.cs
@@ -36,6 +36,13 @@ builder.Services.AddSwaggerGen(c => {
     //c.IncludeXmlComments(xmlPath);
 });
 
+
+// Agregar el HttpClient para usar el servicio durante SSR
+// El CLIENTE lo necesita para hacer peticiones al servidor (a veces) porque este Program.cs es el entry point de la app
+builder.Services.AddScoped(sp=> new HttpClient {
+    BaseAddress = new Uri("http://localhost:5173/")
+});
+
 var app = builder.Build();
 
 


### PR DESCRIPTION
El cliente necesita el Servicio del HttpClient, pero como el entrypoint de la app comienza por el Program.cs del servidor, el servicio se requiere en ambos proyectos para poder hacer el SSR